### PR TITLE
fix 4.8.1 ReleaseKey value

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -137,7 +137,7 @@ namespace DotNetVersions
             // Checking the version using >= enables forward compatibility.
             string CheckFor45PlusVersion(int releaseKey)
             {
-                if (releaseKey >= 533325)
+                if (releaseKey >= 533320)
                     return "4.8.1";
                 if (releaseKey >= 528040)
                     return "4.8";


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#detect-net-framework-45-and-later-versions

Besides, this tool has different result comparing to `System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;`

This one: `4.8.09032`
FrameworkDescription: `.NET Framework 4.8.9105.0`

